### PR TITLE
Fixing cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "phpunit/phpunit": "^9.5",
         "phpunit/phpcov": "^8.2",
         "php-coveralls/php-coveralls": "^2.4",
-        "squizlabs/php_codesniffer": "^3.6"
+        "squizlabs/php_codesniffer": "^3.6",
+        "cache/array-adapter": "^1.1"
     },
     "scripts": {
         "check-quality-code": [

--- a/tests/LongitudeOne/Spatial/Tests/OrmMockTestCase.php
+++ b/tests/LongitudeOne/Spatial/Tests/OrmMockTestCase.php
@@ -15,7 +15,7 @@
 
 namespace LongitudeOne\Spatial\Tests;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Cache\Adapter\PHPArray\ArrayCachePool;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver;
 use Doctrine\DBAL\Exception;
@@ -90,7 +90,7 @@ abstract class OrmMockTestCase extends TestCase
         $path = [realpath(__DIR__.'/Fixtures')];
         $config = new Configuration();
 
-        $config->setMetadataCacheImpl(new ArrayCache());
+        $config->setMetadataCache(new ArrayCachePool());
         $config->setProxyDir(__DIR__.'/Proxies');
         $config->setProxyNamespace('LongitudeOne\Spatial\Tests\Proxies');
         //TODO Warning wrong paramater is provided

--- a/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
+++ b/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
@@ -15,7 +15,7 @@
 
 namespace LongitudeOne\Spatial\Tests;
 
-use Doctrine\Common\Cache\ArrayCache;
+use Cache\Adapter\PHPArray\ArrayCachePool;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Exception;
@@ -526,7 +526,7 @@ abstract class OrmTestCase extends TestCase
         $realPaths = [realpath(__DIR__.'/Fixtures')];
         $config = new Configuration();
 
-        $config->setMetadataCacheImpl(new ArrayCache());
+        $config->setMetadataCache(new ArrayCachePool());
         $config->setProxyDir(__DIR__.'/Proxies');
         $config->setProxyNamespace('LongitudeOne\Spatial\Tests\Proxies');
         //TODO WARNING: a non-expected parameter is provided.


### PR DESCRIPTION
Replacing no-more existing Doctrine\Common\Cache\ArrayCache by Cache\Adapter\PHPArray\ArrayCachePool
Replacing deprecated method setMetadataCacheImpl from Doctrine\ORM\Configuration by setMetadataCache