### PR TITLE
Remove deprecation notice

### DIFF
--- a/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/AbstractSpatialDQLFunction.php
+++ b/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/AbstractSpatialDQLFunction.php
@@ -79,6 +79,8 @@ abstract class AbstractSpatialDQLFunction extends FunctionNode
      * @param Parser $parser parser
      *
      * @throws QueryException Query exception
+     *
+     * @return void
      */
     public function parse(Parser $parser)
     {


### PR DESCRIPTION
Doctrine\ORM\Query\AST\Functions\FunctionNode::parse() has a @return void annotation, which might become a native return type declaration in the future.

Symfony's DebugClassLoader checks for inconsistencies between return types in classes and their parents/interfaces, and triggers a deprecation notice every time the library is used in a Symfony dev environment. This @return annotation fixes that.