### PR TITLE
test(mssql): add support for running tests against ms sql server

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,17 +44,26 @@
         "test": [
             "phpunit --configuration phpunit.mysql5.7.xml",
             "phpunit --configuration phpunit.mysql8.0.xml",
-            "phpunit --configuration phpunit.pgsql.xml"
+            "phpunit --configuration phpunit.pgsql.xml",
+            "phpunit --configuration phpunit.mssql2017.xml",
+            "phpunit --configuration phpunit.mssql2019.xml",
+            "phpunit --configuration phpunit.mssql2022.xml"
         ],
         "test-coverage": [
             "phpunit --configuration phpunit.mysql5.7.xml --coverage-php .phpunit.cache/code-coverage/mysql5.7.cov",
             "phpunit --configuration phpunit.mysql8.0.xml --coverage-php .phpunit.cache/code-coverage/mysql8.0.cov",
             "phpunit --configuration phpunit.pgsql.xml --coverage-php .phpunit.cache/code-coverage/pgsql.cov",
+            "phpunit --configuration phpunit.mssql2017.xml --coverage-php .phpunit.cache/code-coverage/mssql2017.cov",
+            "phpunit --configuration phpunit.mssql2019.xml --coverage-php .phpunit.cache/code-coverage/mssql2019.cov",
+            "phpunit --configuration phpunit.mssql2022.xml --coverage-php .phpunit.cache/code-coverage/mssql2022.cov",
             "phpcov merge --clover .phpunit.cache/code-coverage/clover.xml .phpunit.cache/code-coverage/"
         ],
         "test-mysql5.7": "phpunit --configuration phpunit.mysql5.7.xml",
         "test-mysql8.0": "phpunit --configuration phpunit.mysql8.0.xml",
-        "test-pgsql": "phpunit --configuration phpunit.pgsql.xml"
+        "test-pgsql": "phpunit --configuration phpunit.pgsql.xml",
+        "test-mssql2017": "phpunit --configuration phpunit.mssql2017.xml",
+        "test-mssql2019": "phpunit --configuration phpunit.mssql2019.xml",
+        "test-mssql2022": "phpunit --configuration phpunit.mssql2022.xml"
     },
     "autoload": {
         "psr-0": {

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,3 +19,6 @@ docker exec spatial-php8 cp docker/phpunit*.xml .
 docker exec spatial-php8 composer test-mysql5
 docker exec spatial-php8 composer test-mysql8
 docker exec spatial-php8 composer test-pgsql
+docker exec spatial-php8 composer test-mssql2017
+docker exec spatial-php8 composer test-mssql2019
+docker exec spatial-php8 composer test-mssql2022

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -40,6 +40,43 @@ services:
       MYSQL_PORT: 3306
     ports:
       - "3380:3306"
+  database-mssql2017:
+    build:
+      context: ./mssql
+      args:
+        IMAGE_TAG: "2017-latest"
+        USER_NAME: "root"
+    container_name: "spatial-mssql2017"
+    restart: always
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: mainExtendedToMoreThan8Chars
+    ports:
+      - "1433:1433"
+  database-mssql2019:
+    build:
+      context: ./mssql
+      args:
+        IMAGE_TAG: "2019-latest"
+    container_name: "spatial-mssql2019"
+    restart: always
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: mainExtendedToMoreThan8Chars
+    ports:
+       - "1434:1433"
+  database-mssql2022:
+    build:
+      context: ./mssql
+      args:
+        IMAGE_TAG: "2022-latest"
+    container_name: "spatial-mssql2022"
+    restart: always
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: mainExtendedToMoreThan8Chars
+    ports:
+      - "1435:1433"
   service_doc:
     container_name: "spatial-doc"
     build:

--- a/docker/mssql/Dockerfile
+++ b/docker/mssql/Dockerfile
@@ -1,0 +1,12 @@
+ARG IMAGE_TAG
+ARG USER_NAME=mssql
+FROM mcr.microsoft.com/mssql/server:${IMAGE_TAG}
+USER root
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY usr/src/app .
+RUN chmod +x run-initialization.sh entrypoint.sh
+USER ${USER_NAME}
+EXPOSE 1433
+
+CMD /bin/bash ./entrypoint.sh

--- a/docker/mssql/usr/src/app/create-database.sql
+++ b/docker/mssql/usr/src/app/create-database.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE main;
+GO

--- a/docker/mssql/usr/src/app/entrypoint.sh
+++ b/docker/mssql/usr/src/app/entrypoint.sh
@@ -1,0 +1,1 @@
+/usr/src/app/run-initialization.sh & /opt/mssql/bin/sqlservr

--- a/docker/mssql/usr/src/app/run-initialization.sh
+++ b/docker/mssql/usr/src/app/run-initialization.sh
@@ -1,0 +1,5 @@
+# Wait to be sure that SQL Server came up
+sleep 90s
+
+# Run the setup script to create the DB
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "${MSSQL_SA_PASSWORD:-notProvided}" -d master -i create-database.sql

--- a/docker/php8/Dockerfile
+++ b/docker/php8/Dockerfile
@@ -1,9 +1,16 @@
 FROM php:8.1-fpm-alpine
 
-RUN apk --update --no-cache add bash git postgresql-dev mysql-dev autoconf gcc make g++ \
-        && docker-php-ext-install pdo_pgsql pdo_mysql  \
-        && pecl install pcov \
-        && docker-php-ext-enable pcov pdo_pgsql pdo_mysql
+#Install the package(s)
+#for Microsoft ODBC driver for SQL Server see https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-linux-ver15#alpine-linux
+RUN apk --update --no-cache add bash git postgresql-dev mysql-dev unixodbc-dev autoconf gcc make g++ &&\
+        cd /tmp && \
+        curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/msodbcsql18_18.3.2.1-1_amd64.apk && \
+        curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/mssql-tools18_18.3.1.1-1_amd64.apk && \
+        apk add --allow-untrusted msodbcsql18_18.3.2.1-1_amd64.apk && \
+        apk add --allow-untrusted mssql-tools18_18.3.1.1-1_amd64.apk && \
+        docker-php-ext-install pdo_pgsql pdo_mysql && \
+        pecl install pcov pdo_sqlsrv-5.11.1 sqlsrv-5.11.1  && \
+        docker-php-ext-enable pcov pdo_pgsql pdo_mysql pdo_sqlsrv sqlsrv
 
 #Install composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer

--- a/docker/phpunit.mssql2017.xml
+++ b/docker/phpunit.mssql2017.xml
@@ -20,23 +20,24 @@
             <group>srid</group>
             <group>pgsql-only</group>
             <group>issue</group>
+            <group>mssql-only</group>
         </include>
         <exclude>
             <group>mysql-only</group>
-            <group>mssql-only</group>
+            <group>pgsql-only</group>
         </exclude>
     </groups>
     <php>
-        <var name="db_type" value="pdo_pgsql"/>
-        <var name="db_host" value="spatial-postgis"/>
-        <var name="db_username" value="main"/>
-        <var name="db_password" value="main"/>
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="spatial-mssql2017"/>
+        <var name="db_username" value="sa"/>
+        <var name="db_password" value="mainExtendedToMoreThan8Chars"/>
         <var name="db_name" value="main"/>
-        <var name="db_port" value="5432"/>
-        <!-- PostgreSQL cannot drop current database, -->
+        <var name="db_port" value="1433"/>
+        <var name="db_driver_options" value="TrustServerCertificate=1"/>
+        <!-- mssql cannot drop current database, -->
         <!-- Also, we connect on the alternate database, then we drop the main database -->
-        <var name="db_alternate" value="postgres"/>
-
+        <var name="db_alternate" value="master"/>
         <!-- Select timezone for log -->
         <var name="opt_log_timezone" value="Europe/Paris"/>
         <!-- Select the log level : debug to get each request, info to get each starting test and disconnection -->
@@ -44,7 +45,7 @@
         <!-- Select the directory to store the log files -->
         <var name="opt_log_dir" value=".phpunit.cache/logs"/>
         <!-- Select the log file name -->
-        <var name="opt_log_file" value="pgsql.log"/>
+        <var name="opt_log_file" value="mssql2017.log"/>
     </php>
     <source>
         <include>

--- a/docker/phpunit.mssql2019.xml
+++ b/docker/phpunit.mssql2019.xml
@@ -20,23 +20,24 @@
             <group>srid</group>
             <group>pgsql-only</group>
             <group>issue</group>
+            <group>mssql-only</group>
         </include>
         <exclude>
             <group>mysql-only</group>
-            <group>mssql-only</group>
+            <group>pgsql-only</group>
         </exclude>
     </groups>
     <php>
-        <var name="db_type" value="pdo_pgsql"/>
-        <var name="db_host" value="spatial-postgis"/>
-        <var name="db_username" value="main"/>
-        <var name="db_password" value="main"/>
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="spatial-mssql2019"/>
+        <var name="db_username" value="sa"/>
+        <var name="db_password" value="mainExtendedToMoreThan8Chars"/>
         <var name="db_name" value="main"/>
-        <var name="db_port" value="5432"/>
-        <!-- PostgreSQL cannot drop current database, -->
+        <var name="db_port" value="1433"/>
+        <var name="db_driver_options" value="TrustServerCertificate=1"/>
+        <!-- mssql cannot drop current database, -->
         <!-- Also, we connect on the alternate database, then we drop the main database -->
-        <var name="db_alternate" value="postgres"/>
-
+        <var name="db_alternate" value="master"/>
         <!-- Select timezone for log -->
         <var name="opt_log_timezone" value="Europe/Paris"/>
         <!-- Select the log level : debug to get each request, info to get each starting test and disconnection -->
@@ -44,7 +45,7 @@
         <!-- Select the directory to store the log files -->
         <var name="opt_log_dir" value=".phpunit.cache/logs"/>
         <!-- Select the log file name -->
-        <var name="opt_log_file" value="pgsql.log"/>
+        <var name="opt_log_file" value="mssql2019.log"/>
     </php>
     <source>
         <include>

--- a/docker/phpunit.mssql2022.xml
+++ b/docker/phpunit.mssql2022.xml
@@ -20,23 +20,24 @@
             <group>srid</group>
             <group>pgsql-only</group>
             <group>issue</group>
+            <group>mssql-only</group>
         </include>
         <exclude>
             <group>mysql-only</group>
-            <group>mssql-only</group>
+            <group>pgsql-only</group>
         </exclude>
     </groups>
     <php>
-        <var name="db_type" value="pdo_pgsql"/>
-        <var name="db_host" value="spatial-postgis"/>
-        <var name="db_username" value="main"/>
-        <var name="db_password" value="main"/>
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="spatial-mssql2022"/>
+        <var name="db_username" value="sa"/>
+        <var name="db_password" value="mainExtendedToMoreThan8Chars"/>
         <var name="db_name" value="main"/>
-        <var name="db_port" value="5432"/>
-        <!-- PostgreSQL cannot drop current database, -->
+        <var name="db_port" value="1433"/>
+        <var name="db_driver_options" value="TrustServerCertificate=1"/>
+        <!-- mssql cannot drop current database, -->
         <!-- Also, we connect on the alternate database, then we drop the main database -->
-        <var name="db_alternate" value="postgres"/>
-
+        <var name="db_alternate" value="master"/>
         <!-- Select timezone for log -->
         <var name="opt_log_timezone" value="Europe/Paris"/>
         <!-- Select the log level : debug to get each request, info to get each starting test and disconnection -->
@@ -44,7 +45,7 @@
         <!-- Select the directory to store the log files -->
         <var name="opt_log_dir" value=".phpunit.cache/logs"/>
         <!-- Select the log file name -->
-        <var name="opt_log_file" value="pgsql.log"/>
+        <var name="opt_log_file" value="mssql2022.log"/>
     </php>
     <source>
         <include>

--- a/docker/phpunit.mysql5.7.xml
+++ b/docker/phpunit.mysql5.7.xml
@@ -22,6 +22,7 @@
         </include>
         <exclude>
             <group>pgsql-only</group>
+            <group>mssql-only</group>
             <group>srid</group>
             <group>deprecation</group>
         </exclude>

--- a/docker/phpunit.mysql8.0.xml
+++ b/docker/phpunit.mysql8.0.xml
@@ -22,6 +22,7 @@
         </include>
         <exclude>
             <group>pgsql-only</group>
+            <group>mssql-only</group>
             <group>srid</group>
             <group>deprecation</group>
         </exclude>

--- a/tests/LongitudeOne/Spatial/Tests/Doctrine/ConnectionParameters.php
+++ b/tests/LongitudeOne/Spatial/Tests/Doctrine/ConnectionParameters.php
@@ -59,6 +59,13 @@ class ConnectionParameters
         if (isset($GLOBALS['db_version'])) {
             $connectionParams['driverOptions']['server_version'] = $GLOBALS['db_version'];
         }
+        if (isset($GLOBALS['db_driver_options'])) {
+            $options = explode(',', $GLOBALS['db_driver_options']);
+            foreach ($options as $option) {
+                [$key, $val] = explode('=', $option);
+                $connectionParams['driverOptions'][$key] = $val;
+            }
+        }
 
         return $connectionParams;
     }

--- a/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
+++ b/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Logging;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
@@ -368,6 +369,10 @@ abstract class OrmTestCase extends SpatialTestCase
             return $connection;
         }
 
+        if ($connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            return $connection;
+        }
+
         throw new UnsupportedPlatformException(sprintf(
             'DBAL platform "%s" is not currently supported.',
             $connection->getDatabasePlatform()::class
@@ -477,6 +482,11 @@ abstract class OrmTestCase extends SpatialTestCase
         if ($this->getPlatform() instanceof MySQLPlatform) {
             // Specific functions of MySQL 5.7 and 8.0 database engines
             $this->addSpecificMySqlFunctions($configuration);
+        }
+
+        if ($this->getPlatform() instanceof SQLServerPlatform) {
+            // Specific functions of Microsoft SQL Server 2017, 2019, 2022
+            $this->addSpecificMsSqlFunctions($configuration);
         }
     }
 
@@ -607,6 +617,16 @@ abstract class OrmTestCase extends SpatialTestCase
         $configuration->addCustomStringFunction('PgSql_Summary', SpSummary::class);
         $configuration->addCustomNumericFunction('PgSql_Transform', SpTransform::class);
         $configuration->addCustomNumericFunction('PgSql_Translate', SpTranslate::class);
+    }
+
+    /**
+     * Complete configuration with MS SQL Server spatial functions.
+     *
+     * @param Configuration $configuration the current configuration
+     */
+    private function addSpecificMsSqlFunctions(Configuration $configuration): void
+    {
+        // ready to add related functions for Microsoft SQL Server
     }
 
     /**


### PR DESCRIPTION
I'd like to start to use spatial data with doctrine in one of my projects I'm working on, but unfortunately it uses Microsoft SQL Server. It would be great if `doctrine-spatial` could support it. 

Therefore, I'd like to contribute a potential starting point for MSSQL support:
- [x] scaffold phpunit test suites for MSSQL Server
- [x] add docker compose services for MSSQL Server
- [x] create the test database `main` when MSSQL Server starts
- [x] install PDO drivers for MSSQL Server in php8 service
- [x] configure `SqlServerPlatform` as supported platform in `OrmTestCase`
- [x] add additional database driver options when building the connection parameters to trust the  sql server's self signed certificate 
- [x] add test commands to `composer.json`

Feedback is welcome
