### PR TITLE
test(mssql): add support for running tests against ms sql server (#91)

### DIFF
--- a/.github/phpunit.mssql2019.xml
+++ b/.github/phpunit.mssql2019.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="tests/LongitudeOne/Spatial/Tests/TestInit.php" executionOrder="depends,defects" stopOnFailure="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         stopOnError="true" stopOnWarning="true" stopOnDefect="true" cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests/LongitudeOne/Spatial/Tests</directory>
+        </testsuite>
+    </testsuites>
+    <groups>
+        <include>
+            <group>php</group>
+            <group>dql</group>
+            <group>geometry</group>
+            <group>geography</group>
+            <group>srid</group>
+            <group>pgsql-only</group>
+            <group>issue</group>
+            <group>mssql-only</group>
+        </include>
+        <exclude>
+            <group>mysql-only</group>
+            <group>pgsql-only</group>
+        </exclude>
+    </groups>
+    <php>
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="localhost"/>
+        <var name="db_username" value="sa"/>
+        <var name="db_password" value="mainExtendedToMoreThan8Chars"/>
+        <var name="db_name" value="main"/>
+        <var name="db_port" value="2019"/>
+        <var name="db_driver_options" value="TrustServerCertificate=1"/>
+        <!-- mssql cannot drop current database, -->
+        <!-- Also, we connect on the alternate database, then we drop the main database -->
+        <var name="db_alternate" value="master"/>
+        <!-- Select timezone for log -->
+        <var name="opt_log_timezone" value="Europe/Paris"/>
+        <!-- Select the log level: debug to get each request, info to get each starting test and disconnection -->
+        <var name="opt_log_level" value="debug"/>
+        <!-- Select the directory to store the log files -->
+        <var name="opt_log_dir" value=".phpunit.cache/logs"/>
+        <!-- Select the log file name -->
+        <var name="opt_log_file" value="mssql2019.log"/>
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">lib/</directory>
+        </include>
+    </source>
+</phpunit>

--- a/.github/phpunit.mssql2022.xml
+++ b/.github/phpunit.mssql2022.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="tests/LongitudeOne/Spatial/Tests/TestInit.php" executionOrder="depends,defects" stopOnFailure="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         stopOnError="true" stopOnWarning="true" stopOnDefect="true" cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests/LongitudeOne/Spatial/Tests</directory>
+        </testsuite>
+    </testsuites>
+    <groups>
+        <include>
+            <group>php</group>
+            <group>dql</group>
+            <group>geometry</group>
+            <group>geography</group>
+            <group>srid</group>
+            <group>pgsql-only</group>
+            <group>issue</group>
+            <group>mssql-only</group>
+        </include>
+        <exclude>
+            <group>mysql-only</group>
+            <group>pgsql-only</group>
+        </exclude>
+    </groups>
+    <php>
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="localhost"/>
+        <var name="db_username" value="sa"/>
+        <var name="db_password" value="mainExtendedToMoreThan8Chars"/>
+        <var name="db_name" value="main"/>
+        <var name="db_port" value="2022"/>
+        <var name="db_driver_options" value="TrustServerCertificate=1"/>
+        <!-- mssql cannot drop current database, -->
+        <!-- Also, we connect on the alternate database, then we drop the main database -->
+        <var name="db_alternate" value="master"/>
+        <!-- Select timezone for log -->
+        <var name="opt_log_timezone" value="Europe/Paris"/>
+        <!-- Select the log level: debug to get each request, info to get each starting test and disconnection -->
+        <var name="opt_log_level" value="debug"/>
+        <!-- Select the directory to store the log files -->
+        <var name="opt_log_dir" value=".phpunit.cache/logs"/>
+        <!-- Select the log file name -->
+        <var name="opt_log_file" value="mssql2022.log"/>
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">lib/</directory>
+        </include>
+    </source>
+</phpunit>

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -146,6 +146,7 @@ jobs:
       - name: Create the main database for mssql-2022
         run: sqlcmd -S localhost,2022 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
 
+      # Run the tests
       - name: Run test suite and with coverage for codeclimate for PHP 8.3 and doctrine/orm ^3.1 only
         if: ${{ env.HAS_CC_SECRET == 'true' }}
         uses: paambaati/codeclimate-action@v6.0.0
@@ -291,6 +292,30 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      mssql-2017:
+        # Docker Hub image
+        image: mcr.microsoft.com/mssql/server:2017-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: mainExtendedToMoreThan8Chars
+        ports:
+          - 2017:1433
+      mssql-2019:
+        # Docker Hub image
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: mainExtendedToMoreThan8Chars
+        ports:
+          - 2019:1433
+      mssql-2022:
+        # Docker Hub image
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: mainExtendedToMoreThan8Chars
+        ports:
+          - 2022:1433
     steps:
       -   name: Checkout code
           uses: actions/checkout@v4
@@ -324,6 +349,17 @@ jobs:
       -   name: Force doctrine/orm library to ${{ matrix.orm }}
           run: composer --prefer-stable require doctrine/orm:${{ matrix.orm }} --with-all-dependencies
 
+      # Create the main databases
+      - name: Create the main database for mssql-2017
+        run: sqlcmd -S localhost,2017 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
+
+      - name: Create the main database for mssql-2019
+        run: sqlcmd -S localhost,2019 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
+
+      - name: Create the main database for mssql-2022
+        run: sqlcmd -S localhost,2022 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
+
+      # Run the tests
       -   name: Run test suite for forks or version without code coverage
           run: composer run-script test
 

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -121,6 +121,9 @@ jobs:
       - name: Show libraries
         run: composer show
 
+      - name: Create database main on SQL Server 2017
+        run: docker exec -i mssql-2017 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
+
       - name: Run test suite and with coverage for codeclimate for PHP 8.3 and doctrine/orm ^3.1 only
         if: ${{ env.HAS_CC_SECRET == 'true' }}
         uses: paambaati/codeclimate-action@v6.0.0

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -79,12 +79,22 @@ jobs:
           SA_PASSWORD: mainExtendedToMoreThan8Chars
         ports:
           - 2017:1433
-        # Set health checks to wait until mssql-server has started
-#        options: >-
-#          --health-cmd="/opt/mssql-tools/bin/sqlcmd -S http://localhost:2017 -U sa -P mainExtendedToMoreThan8Chars -Q 'SELECT 1'"
-#          --health-interval 10s
-#          --health-timeout 5s
-#          --health-retries 5
+      mssql-2019:
+        # Docker Hub image
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: mainExtendedToMoreThan8Chars
+        ports:
+          - 2019:1433
+      mssql-2022:
+        # Docker Hub image
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: Y
+          SA_PASSWORD: mainExtendedToMoreThan8Chars
+        ports:
+          - 2022:1433
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -126,8 +136,15 @@ jobs:
         with:
           install: sqlclient
 
+      # Create the main databases
       - name: Create the main database for mssql-2017
         run: sqlcmd -S localhost,2017 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
+
+      - name: Create the main database for mssql-2019
+        run: sqlcmd -S localhost,2019 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
+
+      - name: Create the main database for mssql-2022
+        run: sqlcmd -S localhost,2022 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
 
       - name: Run test suite and with coverage for codeclimate for PHP 8.3 and doctrine/orm ^3.1 only
         if: ${{ env.HAS_CC_SECRET == 'true' }}

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -127,7 +127,7 @@ jobs:
           install: sqlclient
 
       - name: Create the main database for mssql-2017
-        run: sqlcmd -S localhost -p 2017 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
+        run: sqlcmd -S localhost,2017 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
 
       - name: Run test suite and with coverage for codeclimate for PHP 8.3 and doctrine/orm ^3.1 only
         if: ${{ env.HAS_CC_SECRET == 'true' }}

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -121,10 +121,12 @@ jobs:
       - name: Show libraries
         run: composer show
 
-      - name: Create database main on SQL Server 2017
+      - name: Install sqlclient for mssql
         uses: potatoqualitee/mssqlsuite@v1.7
         with:
           install: sqlclient
+
+      - name: Create the main database for mssql-2017
         run: sqlcmd -S localhost -p 2017 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
 
       - name: Run test suite and with coverage for codeclimate for PHP 8.3 and doctrine/orm ^3.1 only

--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -122,7 +122,10 @@ jobs:
         run: composer show
 
       - name: Create database main on SQL Server 2017
-        run: docker exec -i mssql-2017 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
+        uses: potatoqualitee/mssqlsuite@v1.7
+        with:
+          install: sqlclient
+        run: sqlcmd -S localhost -p 2017 -U sa -P mainExtendedToMoreThan8Chars -Q "CREATE DATABASE main;"
 
       - name: Run test suite and with coverage for codeclimate for PHP 8.3 and doctrine/orm ^3.1 only
         if: ${{ env.HAS_CC_SECRET == 'true' }}

--- a/composer.json
+++ b/composer.json
@@ -44,17 +44,26 @@
         "test": [
             "phpunit --configuration phpunit.mysql5.7.xml",
             "phpunit --configuration phpunit.mysql8.0.xml",
-            "phpunit --configuration phpunit.pgsql.xml"
+            "phpunit --configuration phpunit.pgsql.xml",
+            "phpunit --configuration phpunit.mssql2017.xml",
+            "phpunit --configuration phpunit.mssql2019.xml",
+            "phpunit --configuration phpunit.mssql2022.xml"
         ],
         "test-coverage": [
             "phpunit --configuration phpunit.mysql5.7.xml --coverage-php .phpunit.cache/code-coverage/mysql5.7.cov",
             "phpunit --configuration phpunit.mysql8.0.xml --coverage-php .phpunit.cache/code-coverage/mysql8.0.cov",
             "phpunit --configuration phpunit.pgsql.xml --coverage-php .phpunit.cache/code-coverage/pgsql.cov",
+            "phpunit --configuration phpunit.mssql2017.xml --coverage-php .phpunit.cache/code-coverage/mssql2017.cov",
+            "phpunit --configuration phpunit.mssql2019.xml --coverage-php .phpunit.cache/code-coverage/mssql2019.cov",
+            "phpunit --configuration phpunit.mssql2022.xml --coverage-php .phpunit.cache/code-coverage/mssql2022.cov",
             "phpcov merge --clover .phpunit.cache/code-coverage/clover.xml .phpunit.cache/code-coverage/"
         ],
         "test-mysql5.7": "phpunit --configuration phpunit.mysql5.7.xml",
         "test-mysql8.0": "phpunit --configuration phpunit.mysql8.0.xml",
-        "test-pgsql": "phpunit --configuration phpunit.pgsql.xml"
+        "test-pgsql": "phpunit --configuration phpunit.pgsql.xml",
+        "test-mssql2017": "phpunit --configuration phpunit.mssql2017.xml",
+        "test-mssql2019": "phpunit --configuration phpunit.mssql2019.xml",
+        "test-mssql2022": "phpunit --configuration phpunit.mssql2022.xml"
     },
     "autoload": {
         "psr-0": {

--- a/docker/README.md
+++ b/docker/README.md
@@ -19,3 +19,6 @@ docker exec spatial-php8 cp docker/phpunit*.xml .
 docker exec spatial-php8 composer test-mysql5
 docker exec spatial-php8 composer test-mysql8
 docker exec spatial-php8 composer test-pgsql
+docker exec spatial-php8 composer test-mssql2017
+docker exec spatial-php8 composer test-mssql2019
+docker exec spatial-php8 composer test-mssql2022

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -40,6 +40,43 @@ services:
       MYSQL_PORT: 3306
     ports:
       - "3380:3306"
+  database-mssql2017:
+    build:
+      context: ./mssql
+      args:
+        IMAGE_TAG: "2017-latest"
+        USER_NAME: "root"
+    container_name: "spatial-mssql2017"
+    restart: always
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: mainExtendedToMoreThan8Chars
+    ports:
+      - "1433:1433"
+  database-mssql2019:
+    build:
+      context: ./mssql
+      args:
+        IMAGE_TAG: "2019-latest"
+    container_name: "spatial-mssql2019"
+    restart: always
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: mainExtendedToMoreThan8Chars
+    ports:
+       - "1434:1433"
+  database-mssql2022:
+    build:
+      context: ./mssql
+      args:
+        IMAGE_TAG: "2022-latest"
+    container_name: "spatial-mssql2022"
+    restart: always
+    environment:
+      ACCEPT_EULA: Y
+      MSSQL_SA_PASSWORD: mainExtendedToMoreThan8Chars
+    ports:
+      - "1435:1433"
   service_doc:
     container_name: "spatial-doc"
     build:

--- a/docker/mssql/Dockerfile
+++ b/docker/mssql/Dockerfile
@@ -1,0 +1,12 @@
+ARG IMAGE_TAG
+ARG USER_NAME=mssql
+FROM mcr.microsoft.com/mssql/server:${IMAGE_TAG}
+USER root
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY usr/src/app .
+RUN chmod +x run-initialization.sh entrypoint.sh
+USER ${USER_NAME}
+EXPOSE 1433
+
+CMD /bin/bash ./entrypoint.sh

--- a/docker/mssql/usr/src/app/create-database.sql
+++ b/docker/mssql/usr/src/app/create-database.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE main;
+GO

--- a/docker/mssql/usr/src/app/entrypoint.sh
+++ b/docker/mssql/usr/src/app/entrypoint.sh
@@ -1,0 +1,1 @@
+/usr/src/app/run-initialization.sh & /opt/mssql/bin/sqlservr

--- a/docker/mssql/usr/src/app/run-initialization.sh
+++ b/docker/mssql/usr/src/app/run-initialization.sh
@@ -1,0 +1,5 @@
+# Wait to be sure that SQL Server came up
+sleep 90s
+
+# Run the setup script to create the DB
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P "${MSSQL_SA_PASSWORD:-notProvided}" -d master -i create-database.sql

--- a/docker/php8/Dockerfile
+++ b/docker/php8/Dockerfile
@@ -1,9 +1,16 @@
 FROM php:8.1-fpm-alpine
 
-RUN apk --update --no-cache add bash git postgresql-dev mysql-dev autoconf gcc make g++ \
-        && docker-php-ext-install pdo_pgsql pdo_mysql  \
-        && pecl install pcov \
-        && docker-php-ext-enable pcov pdo_pgsql pdo_mysql
+#Install the package(s)
+#for Microsoft ODBC driver for SQL Server see https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-linux-ver15#alpine-linux
+RUN apk --update --no-cache add bash git postgresql-dev mysql-dev unixodbc-dev autoconf gcc make g++ &&\
+        cd /tmp && \
+        curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/msodbcsql18_18.3.2.1-1_amd64.apk && \
+        curl -O https://download.microsoft.com/download/3/5/5/355d7943-a338-41a7-858d-53b259ea33f5/mssql-tools18_18.3.1.1-1_amd64.apk && \
+        apk add --allow-untrusted msodbcsql18_18.3.2.1-1_amd64.apk && \
+        apk add --allow-untrusted mssql-tools18_18.3.1.1-1_amd64.apk && \
+        docker-php-ext-install pdo_pgsql pdo_mysql && \
+        pecl install pcov pdo_sqlsrv-5.11.1 sqlsrv-5.11.1  && \
+        docker-php-ext-enable pcov pdo_pgsql pdo_mysql pdo_sqlsrv sqlsrv
 
 #Install composer
 COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer

--- a/docker/phpunit.mssql2017.xml
+++ b/docker/phpunit.mssql2017.xml
@@ -20,23 +20,24 @@
             <group>srid</group>
             <group>pgsql-only</group>
             <group>issue</group>
+            <group>mssql-only</group>
         </include>
         <exclude>
             <group>mysql-only</group>
-            <group>mssql-only</group>
+            <group>pgsql-only</group>
         </exclude>
     </groups>
     <php>
-        <var name="db_type" value="pdo_pgsql"/>
-        <var name="db_host" value="spatial-postgis"/>
-        <var name="db_username" value="main"/>
-        <var name="db_password" value="main"/>
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="spatial-mssql2017"/>
+        <var name="db_username" value="sa"/>
+        <var name="db_password" value="mainExtendedToMoreThan8Chars"/>
         <var name="db_name" value="main"/>
-        <var name="db_port" value="5432"/>
-        <!-- PostgreSQL cannot drop current database, -->
+        <var name="db_port" value="1433"/>
+        <var name="db_driver_options" value="TrustServerCertificate=1"/>
+        <!-- mssql cannot drop current database, -->
         <!-- Also, we connect on the alternate database, then we drop the main database -->
-        <var name="db_alternate" value="postgres"/>
-
+        <var name="db_alternate" value="master"/>
         <!-- Select timezone for log -->
         <var name="opt_log_timezone" value="Europe/Paris"/>
         <!-- Select the log level : debug to get each request, info to get each starting test and disconnection -->
@@ -44,7 +45,7 @@
         <!-- Select the directory to store the log files -->
         <var name="opt_log_dir" value=".phpunit.cache/logs"/>
         <!-- Select the log file name -->
-        <var name="opt_log_file" value="pgsql.log"/>
+        <var name="opt_log_file" value="mssql2017.log"/>
     </php>
     <source>
         <include>

--- a/docker/phpunit.mssql2019.xml
+++ b/docker/phpunit.mssql2019.xml
@@ -20,23 +20,24 @@
             <group>srid</group>
             <group>pgsql-only</group>
             <group>issue</group>
+            <group>mssql-only</group>
         </include>
         <exclude>
             <group>mysql-only</group>
-            <group>mssql-only</group>
+            <group>pgsql-only</group>
         </exclude>
     </groups>
     <php>
-        <var name="db_type" value="pdo_pgsql"/>
-        <var name="db_host" value="spatial-postgis"/>
-        <var name="db_username" value="main"/>
-        <var name="db_password" value="main"/>
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="spatial-mssql2019"/>
+        <var name="db_username" value="sa"/>
+        <var name="db_password" value="mainExtendedToMoreThan8Chars"/>
         <var name="db_name" value="main"/>
-        <var name="db_port" value="5432"/>
-        <!-- PostgreSQL cannot drop current database, -->
+        <var name="db_port" value="1433"/>
+        <var name="db_driver_options" value="TrustServerCertificate=1"/>
+        <!-- mssql cannot drop current database, -->
         <!-- Also, we connect on the alternate database, then we drop the main database -->
-        <var name="db_alternate" value="postgres"/>
-
+        <var name="db_alternate" value="master"/>
         <!-- Select timezone for log -->
         <var name="opt_log_timezone" value="Europe/Paris"/>
         <!-- Select the log level : debug to get each request, info to get each starting test and disconnection -->
@@ -44,7 +45,7 @@
         <!-- Select the directory to store the log files -->
         <var name="opt_log_dir" value=".phpunit.cache/logs"/>
         <!-- Select the log file name -->
-        <var name="opt_log_file" value="pgsql.log"/>
+        <var name="opt_log_file" value="mssql2019.log"/>
     </php>
     <source>
         <include>

--- a/docker/phpunit.mssql2022.xml
+++ b/docker/phpunit.mssql2022.xml
@@ -20,23 +20,24 @@
             <group>srid</group>
             <group>pgsql-only</group>
             <group>issue</group>
+            <group>mssql-only</group>
         </include>
         <exclude>
             <group>mysql-only</group>
-            <group>mssql-only</group>
+            <group>pgsql-only</group>
         </exclude>
     </groups>
     <php>
-        <var name="db_type" value="pdo_pgsql"/>
-        <var name="db_host" value="spatial-postgis"/>
-        <var name="db_username" value="main"/>
-        <var name="db_password" value="main"/>
+        <var name="db_type" value="pdo_sqlsrv"/>
+        <var name="db_host" value="spatial-mssql2022"/>
+        <var name="db_username" value="sa"/>
+        <var name="db_password" value="mainExtendedToMoreThan8Chars"/>
         <var name="db_name" value="main"/>
-        <var name="db_port" value="5432"/>
-        <!-- PostgreSQL cannot drop current database, -->
+        <var name="db_port" value="1433"/>
+        <var name="db_driver_options" value="TrustServerCertificate=1"/>
+        <!-- mssql cannot drop current database, -->
         <!-- Also, we connect on the alternate database, then we drop the main database -->
-        <var name="db_alternate" value="postgres"/>
-
+        <var name="db_alternate" value="master"/>
         <!-- Select timezone for log -->
         <var name="opt_log_timezone" value="Europe/Paris"/>
         <!-- Select the log level : debug to get each request, info to get each starting test and disconnection -->
@@ -44,7 +45,7 @@
         <!-- Select the directory to store the log files -->
         <var name="opt_log_dir" value=".phpunit.cache/logs"/>
         <!-- Select the log file name -->
-        <var name="opt_log_file" value="pgsql.log"/>
+        <var name="opt_log_file" value="mssql2022.log"/>
     </php>
     <source>
         <include>

--- a/docker/phpunit.mysql5.7.xml
+++ b/docker/phpunit.mysql5.7.xml
@@ -22,6 +22,7 @@
         </include>
         <exclude>
             <group>pgsql-only</group>
+            <group>mssql-only</group>
             <group>srid</group>
             <group>deprecation</group>
         </exclude>

--- a/docker/phpunit.mysql8.0.xml
+++ b/docker/phpunit.mysql8.0.xml
@@ -22,6 +22,7 @@
         </include>
         <exclude>
             <group>pgsql-only</group>
+            <group>mssql-only</group>
             <group>srid</group>
             <group>deprecation</group>
         </exclude>

--- a/quality/php-mess-detector/test-ruleset.xml
+++ b/quality/php-mess-detector/test-ruleset.xml
@@ -28,6 +28,8 @@
         <exclude name="CouplingBetweenObjects"/>
         <exclude name="NumberOfChildren"/>
     </rule>
-    <!-- Import the entire unused code rule set -->
-    <rule ref="rulesets/unusedcode.xml"/>
+    <!-- Import the entire unused code rule set but Unused code rule (because no specific functions for MSSQL Server -->
+    <rule ref="rulesets/unusedcode.xml">
+        <exclude name="UnusedFormalParameter"/>
+    </rule>
 </ruleset>

--- a/tests/LongitudeOne/Spatial/Tests/Doctrine/ConnectionParameters.php
+++ b/tests/LongitudeOne/Spatial/Tests/Doctrine/ConnectionParameters.php
@@ -59,6 +59,13 @@ class ConnectionParameters
         if (isset($GLOBALS['db_version'])) {
             $connectionParams['driverOptions']['server_version'] = $GLOBALS['db_version'];
         }
+        if (isset($GLOBALS['db_driver_options'])) {
+            $options = explode(',', $GLOBALS['db_driver_options']);
+            foreach ($options as $option) {
+                [$key, $val] = explode('=', $option);
+                $connectionParams['driverOptions'][$key] = $val;
+            }
+        }
 
         return $connectionParams;
     }

--- a/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
+++ b/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
@@ -565,6 +565,7 @@ abstract class OrmTestCase extends SpatialTestCase
     private function addSpecificMsSqlFunctions(Configuration $configuration): void
     {
         // ready to add related functions for Microsoft SQL Server
+        // $configuration->addCustomNumericFunction('foo', SpSqlFoo::class);
     }
 
     /**

--- a/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
+++ b/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
@@ -558,6 +558,16 @@ abstract class OrmTestCase extends SpatialTestCase
     }
 
     /**
+     * Complete configuration with MS SQL Server spatial functions.
+     *
+     * @param Configuration $configuration the current configuration
+     */
+    private function addSpecificMsSqlFunctions(Configuration $configuration): void
+    {
+        // ready to add related functions for Microsoft SQL Server
+    }
+
+    /**
      * Complete configuration with MySQL spatial functions.
      *
      * @param Configuration $configuration the current configuration
@@ -617,16 +627,6 @@ abstract class OrmTestCase extends SpatialTestCase
         $configuration->addCustomStringFunction('PgSql_Summary', SpSummary::class);
         $configuration->addCustomNumericFunction('PgSql_Transform', SpTransform::class);
         $configuration->addCustomNumericFunction('PgSql_Translate', SpTranslate::class);
-    }
-
-    /**
-     * Complete configuration with MS SQL Server spatial functions.
-     *
-     * @param Configuration $configuration the current configuration
-     */
-    private function addSpecificMsSqlFunctions(Configuration $configuration): void
-    {
-        // ready to add related functions for Microsoft SQL Server
     }
 
     /**

--- a/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
+++ b/tests/LongitudeOne/Spatial/Tests/OrmTestCase.php
@@ -26,6 +26,7 @@ use Doctrine\DBAL\Logging;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SQLServerPlatform;
 use Doctrine\DBAL\Types\Exception\UnknownColumnType;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
@@ -368,6 +369,10 @@ abstract class OrmTestCase extends SpatialTestCase
             return $connection;
         }
 
+        if ($connection->getDatabasePlatform() instanceof SQLServerPlatform) {
+            return $connection;
+        }
+
         throw new UnsupportedPlatformException(sprintf(
             'DBAL platform "%s" is not currently supported.',
             $connection->getDatabasePlatform()::class
@@ -477,6 +482,11 @@ abstract class OrmTestCase extends SpatialTestCase
         if ($this->getPlatform() instanceof MySQLPlatform) {
             // Specific functions of MySQL 5.7 and 8.0 database engines
             $this->addSpecificMySqlFunctions($configuration);
+        }
+
+        if ($this->getPlatform() instanceof SQLServerPlatform) {
+            // Specific functions of Microsoft SQL Server 2017, 2019, 2022
+            $this->addSpecificMsSqlFunctions($configuration);
         }
     }
 
@@ -607,6 +617,16 @@ abstract class OrmTestCase extends SpatialTestCase
         $configuration->addCustomStringFunction('PgSql_Summary', SpSummary::class);
         $configuration->addCustomNumericFunction('PgSql_Transform', SpTransform::class);
         $configuration->addCustomNumericFunction('PgSql_Translate', SpTranslate::class);
+    }
+
+    /**
+     * Complete configuration with MS SQL Server spatial functions.
+     *
+     * @param Configuration $configuration the current configuration
+     */
+    private function addSpecificMsSqlFunctions(Configuration $configuration): void
+    {
+        // ready to add related functions for Microsoft SQL Server
     }
 
     /**


### PR DESCRIPTION
MS-SQL Server support :
- [x] scaffold phpunit test suites for MSSQL Server by @DaveHint 
- [x] add docker compose services for MSSQL Server by @DaveHint 
- [x] create the test database `main` when MSSQL Server starts by @DaveHint 
- [x] install PDO drivers for MSSQL Server in php8 service by @DaveHint 
- [x] configure `SqlServerPlatform` as supported platform in `OrmTestCase` by @DaveHint 
- [x] add additional database driver options when building the connection parameters to trust the  sql server's self signed certificate  by @DaveHint 
- [x] add test commands to `composer.json`  by @DaveHint 
- [x] add phpunit files for the CI/CD by @Alexandre-T 
- [x] add sql server services in the CI by @Alexandre-T 

