### PR TITLE
Standard function are not compatible if specialized functions exist

### DIFF
--- a/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/Standard/StBuffer.php
+++ b/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/Standard/StBuffer.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 namespace LongitudeOne\Spatial\ORM\Query\AST\Functions\Standard;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use LongitudeOne\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
@@ -75,6 +74,6 @@ class StBuffer extends AbstractSpatialDQLFunction
      */
     protected function getPlatforms(): array
     {
-        return [PostgreSQLPlatform::class, MySQLPlatform::class];
+        return [PostgreSQLPlatform::class];
     }
 }

--- a/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/Standard/StDistance.php
+++ b/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/Standard/StDistance.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 namespace LongitudeOne\Spatial\ORM\Query\AST\Functions\Standard;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use LongitudeOne\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
@@ -76,6 +75,6 @@ class StDistance extends AbstractSpatialDQLFunction
      */
     protected function getPlatforms(): array
     {
-        return [PostgreSQLPlatform::class, MySQLPlatform::class];
+        return [PostgreSQLPlatform::class];
     }
 }

--- a/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/Standard/StGeometryType.php
+++ b/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/Standard/StGeometryType.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 namespace LongitudeOne\Spatial\ORM\Query\AST\Functions\Standard;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use LongitudeOne\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
@@ -75,6 +74,6 @@ class StGeometryType extends AbstractSpatialDQLFunction
      */
     protected function getPlatforms(): array
     {
-        return [PostgreSQLPlatform::class, MySQLPlatform::class];
+        return [PostgreSQLPlatform::class];
     }
 }

--- a/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/Standard/StPoint.php
+++ b/lib/LongitudeOne/Spatial/ORM/Query/AST/Functions/Standard/StPoint.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 namespace LongitudeOne\Spatial\ORM\Query\AST\Functions\Standard;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use LongitudeOne\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
@@ -76,6 +75,6 @@ class StPoint extends AbstractSpatialDQLFunction
      */
     protected function getPlatforms(): array
     {
-        return [PostgreSQLPlatform::class, MySQLPlatform::class];
+        return [PostgreSQLPlatform::class];
     }
 }

--- a/tests/LongitudeOne/Spatial/Tests/ORM/Query/AST/Functions/Standard/StBufferTest.php
+++ b/tests/LongitudeOne/Spatial/Tests/ORM/Query/AST/Functions/Standard/StBufferTest.php
@@ -45,7 +45,6 @@ class StBufferTest extends PersistOrmTestCase
     {
         $this->usesEntity(self::POINT_ENTITY);
         $this->supportsPlatform(PostgreSQLPlatform::class);
-        // TODO check if this function is supported by MySQL or if I missed a platform
 
         parent::setUp();
     }

--- a/tests/LongitudeOne/Spatial/Tests/ORM/Query/AST/Functions/Standard/StGeometryTypeTest.php
+++ b/tests/LongitudeOne/Spatial/Tests/ORM/Query/AST/Functions/Standard/StGeometryTypeTest.php
@@ -46,7 +46,6 @@ class StGeometryTypeTest extends PersistOrmTestCase
     {
         $this->usesEntity(self::LINESTRING_ENTITY);
         $this->supportsPlatform(PostgreSQLPlatform::class);
-        // TODO Check if I missed MySQL80Platform
 
         parent::setUp();
     }


### PR DESCRIPTION
It seems the compatibility declaration was still there by accident.