### PR TITLE
Add Support for doctrine/orm 3.3.*

### DIFF
--- a/lib/LongitudeOne/Spatial/DBAL/Platform/AbstractPlatform.php
+++ b/lib/LongitudeOne/Spatial/DBAL/Platform/AbstractPlatform.php
@@ -138,10 +138,6 @@ abstract class AbstractPlatform implements PlatformInterface
 
         $sqlType = mb_strtolower($type->getSQLType());
 
-        if ($type instanceof GeographyType && 'geography' !== $sqlType) {
-            $sqlType = sprintf('geography(%s)', $sqlType);
-        }
-
         return [$sqlType];
     }
 


### PR DESCRIPTION
Hi, I've encountered a problem with doctrine/orm:^3.2 (exact version 3.3.1).
I'm developing an application that only needs to use the geographic point at the moment.
I haven't studied the whole library and I don't have precise cases for testing each one. But I did run into this problem with `make:migration` command :
```

In AbstractPlatform.php line 454:
                                                                                                      
  Unknown database type point requested, Doctrine\DBAL\Platforms\MySQL80Platform may not support it.  
                                                                                                      
```
Which I solved by removing some of the config in the doctrine type mapping declarations.

So I'm taking this opportunity to open this PR to submit the solution, without being certain that it's valid for the rest of the library. 