### PR TITLE
Remove ext-json since included in php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     },
     "require": {
         "php": "^8.1",
-        "ext-json": "*",
         "ext-mbstring": "*",
         "longitude-one/geo-parser": "^3.0.1",
         "longitude-one/wkt-parser": "^3.0.0",


### PR DESCRIPTION
Doc here https://php.watch/versions/8.0/ext-json

Issued from https://github.com/longitude-one/doctrine-spatial/issues/121