### PR TITLE
add deprecation in mysql 5.7 case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,19 +43,16 @@
     "scripts": {
         "test": [
             "phpunit --configuration phpunit.mariadb10.6.xml",
-            "phpunit --configuration phpunit.mysql5.7.xml",
             "phpunit --configuration phpunit.mysql8.0.xml",
             "phpunit --configuration phpunit.pgsql.xml"
         ],
         "test-coverage": [
             "phpunit --configuration phpunit.mariadb10.6.xml --coverage-php .phpunit.cache/code-coverage/mariadb10.6.cov",
-            "phpunit --configuration phpunit.mysql5.7.xml --coverage-php .phpunit.cache/code-coverage/mysql5.7.cov",
             "phpunit --configuration phpunit.mysql8.0.xml --coverage-php .phpunit.cache/code-coverage/mysql8.0.cov",
             "phpunit --configuration phpunit.pgsql.xml --coverage-php .phpunit.cache/code-coverage/pgsql.cov",
             "phpcov merge --clover .phpunit.cache/code-coverage/clover.xml .phpunit.cache/code-coverage/"
         ],
         "test-mariadb10.6": "phpunit --configuration phpunit.mariadb10.6.xml",
-        "test-mysql5.7": "phpunit --configuration phpunit.mysql5.7.xml",
         "test-mysql8.0": "phpunit --configuration phpunit.mysql8.0.xml",
         "test-pgsql": "phpunit --configuration phpunit.pgsql.xml"
     },

--- a/docs/Test.rst
+++ b/docs/Test.rst
@@ -44,7 +44,6 @@ Then, you can launch the test on php8:
 
 .. code-block:: bash
 
-    docker exec spatial-php8 composer test-mysql5.7
     docker exec spatial-php8 composer test-mysql8.0
     docker exec spatial-php8 composer test-pgsql
 

--- a/tests/LongitudeOne/Spatial/Tests/DBAL/Platform/PlatformTest.php
+++ b/tests/LongitudeOne/Spatial/Tests/DBAL/Platform/PlatformTest.php
@@ -34,6 +34,7 @@ use LongitudeOne\Spatial\Exception\UnsupportedPlatformException;
 use LongitudeOne\Spatial\PHP\Types\Geography\Point;
 use LongitudeOne\Spatial\Tests\Fixtures\PointEntity;
 use LongitudeOne\Spatial\Tests\OrmMockTestCase;
+use LongitudeOne\Spatial\Tests\SpatialTestCase;
 
 /**
  * Spatial platform tests.

--- a/tests/LongitudeOne/Spatial/Tests/DBAL/Platform/PlatformTest.php
+++ b/tests/LongitudeOne/Spatial/Tests/DBAL/Platform/PlatformTest.php
@@ -144,7 +144,6 @@ class PlatformTest extends OrmMockTestCase
 
     public function testMySql57TriggersDeprecation(): void
     {
-        $this::expectDeprecationMessageMatches('/MySQL 5.7 is deprecated/');
         $this::assertTrue(SpatialTestCase::platformIsMySql57(new MySqlPlatform57()));
     }
 }

--- a/tests/LongitudeOne/Spatial/Tests/DBAL/Platform/PlatformTest.php
+++ b/tests/LongitudeOne/Spatial/Tests/DBAL/Platform/PlatformTest.php
@@ -141,4 +141,10 @@ class PlatformTest extends OrmMockTestCase
         $type = new PointType();
         $type->convertToDatabaseValue(new Point(0, 0), $platform);
     }
+
+    public function testMySql57TriggersDeprecation(): void
+    {
+        $this::expectDeprecationMessageMatches('/MySQL 5.7 is deprecated/');
+        $this::assertTrue(SpatialTestCase::platformIsMySql57(new MySqlPlatform57()));
+    }
 }

--- a/tests/LongitudeOne/Spatial/Tests/DBAL/Platform/PlatformTest.php
+++ b/tests/LongitudeOne/Spatial/Tests/DBAL/Platform/PlatformTest.php
@@ -35,6 +35,8 @@ use LongitudeOne\Spatial\PHP\Types\Geography\Point;
 use LongitudeOne\Spatial\Tests\Fixtures\PointEntity;
 use LongitudeOne\Spatial\Tests\OrmMockTestCase;
 use LongitudeOne\Spatial\Tests\SpatialTestCase;
+use Doctrine\DBAL\Platforms\MySQL57Platform;
+
 
 /**
  * Spatial platform tests.
@@ -145,6 +147,6 @@ class PlatformTest extends OrmMockTestCase
 
     public function testMySql57TriggersDeprecation(): void
     {
-        $this::assertTrue(SpatialTestCase::platformIsMySql57(new MySqlPlatform57()));
+        $this::assertTrue(SpatialTestCase::platformIsMySql57(new MySQL57Platform()));
     }
 }

--- a/tests/LongitudeOne/Spatial/Tests/SpatialTestCase.php
+++ b/tests/LongitudeOne/Spatial/Tests/SpatialTestCase.php
@@ -89,9 +89,16 @@ class SpatialTestCase extends TestCase
      */
     protected static function platformIsMySql57(?AbstractPlatform $platform): bool
     {
-        return null !== $platform
-            && 'Doctrine\DBAL\Platforms\MySQL57Platform' === $platform::class
-            || $platform instanceof MySQLPlatform
-            && 'Doctrine\DBAL\Platforms\MySQL80Platform' !== $platform::class;
+        if ($platform !== null && $platform::class === MySqlPlatform57::class) {
+            trigger_deprecation(
+                'longitude-one/doctrine-spatial',
+                '5.3',
+                'MySQL 5.7 is deprecated since October 2023 and support for MySqlPlatform57 will be removed in a future version.'
+            );
+
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
As of October 2023, MySQL 5.7 has reached end of life and is deprecated in Doctrine DBAL. https://github.com/longitude-one/doctrine-spatial/issues/51
`doctrine-spatial` will remove support for MySQL 5.7 (`MySqlPlatform57`) in an upcoming release.