### PR TITLE
feat: openup versions available without breaks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
         "doctrine/orm": "^2.19|^3.1"
     },
     "require-dev": {
-        "monolog/monolog": "^2.0",
-        "phpunit/phpunit": "^10.0",
-        "phpunit/phpcov": "^9",
+        "monolog/monolog": "^2.0|^3.0",
+        "phpunit/phpunit": "^10.0|^11.0",
+        "phpunit/phpcov": "^9|^10.0",
         "cache/array-adapter": "^1.1",
         "dg/bypass-finals": "^1.3",
         "composer/semver": "^3.4"


### PR DESCRIPTION
 * Opened "phpunit/phpcov" package to "^9|^10.0" version
 * Opened "phpunit/phpunit" package to "^10.0|^11.0" version
 * Opened "monolog/monolog" package to "^2.0|^3.0" version


This allows install new versions in composer install automatically without break previous versions supported.

Only applied in require-dev dependencies