### PR TITLE
Add mapping_types for point in Configuration.rst

### DIFF
--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -24,7 +24,7 @@ Declare your geometric types
                 point:      LongitudeOne\Spatial\DBAL\Types\Geometry\PointType
                 polygon:    LongitudeOne\Spatial\DBAL\Types\Geometry\PolygonType
                 linestring: LongitudeOne\Spatial\DBAL\Types\Geometry\LineStringType
-             mapping_types:
+            mapping_types:
                 point: point
 
 Now, you can :doc:`create an entity <./Entity>` with a ``geometry``, ``point``, ``polygon`` and a ``linestring`` type.

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -24,6 +24,8 @@ Declare your geometric types
                 point:      LongitudeOne\Spatial\DBAL\Types\Geometry\PointType
                 polygon:    LongitudeOne\Spatial\DBAL\Types\Geometry\PolygonType
                 linestring: LongitudeOne\Spatial\DBAL\Types\Geometry\LineStringType
+             mapping_types:
+                point: point
 
 Now, you can :doc:`create an entity <./Entity>` with a ``geometry``, ``point``, ``polygon`` and a ``linestring`` type.
 


### PR DESCRIPTION
Hi,

Thanks for this library! In the docs for Symfony it is missing that you also have to define the mapping type. Without that, the doctrine commands will error with "Unknown database type point requested, Doctrine\DBAL\Platforms\MySQL80Platform may not support it."