### PR TITLE
fix: update dg/bypass-finals version constraint to be less than 1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "phpunit/phpunit": "^10.0|^11.0",
         "phpunit/phpcov": "^9|^10",
         "cache/array-adapter": "^1.1",
-        "dg/bypass-finals": "^1.3",
+        "dg/bypass-finals": "<1.11",
         "composer/semver": "^3.4",
         "symfony/var-exporter": "^6.4"
     },


### PR DESCRIPTION
closes #157 