### PR TITLE
docs: prepare 6.0 release documentation and versioning

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,8 +4,8 @@
 /.github export-ignore
 /.gitignore export-ignore
 /.gitattributes export-ignore
-/.codeclimate.yml export-ignore
 /.readthedocs.yaml export-ignore
+/.versionrc.json export-ignore
 
 # Ignore documentation and quality tools
 /docs export-ignore

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,6 +1,16 @@
 {
   "releaseCommitMessageFormat": "chore(release): v{{currentTag}} 🎉",
   "packageFiles": [],
+  "bumpFiles": [
+    {
+      "filename": "docs/Installation.rst",
+      "updater": "quality/commit-and-tag-version/installation-version-updater.cjs"
+    },
+    {
+      "filename": "docs/conf.py",
+      "updater": "quality/commit-and-tag-version/sphinx-release-updater.cjs"
+    }
+  ],
   "types": [
     {"type": "feat", "section": "✨ New Features"},
     {"type": "fix", "section": "🐛 Bug Fixes"},

--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ It also includes a glossary for the main spatial types and functions supported b
 > [!NOTE]
 > A major release may increase the minimum supported PHP version. Other breaking changes are documented in the changelog.
 
-| Version | PHP compatibility           | Tested on       | Doctrine ORM             | Tested against Doctrine ORM | Released     | Active support   | Security fixes   |
-|---------|-----------------------------|-----------------|--------------------------|-----------------------------|--------------|------------------|------------------|
-| 5       | 8.1 - 8.2 - 8.3 - 8.4 - 8.5 | From 8.1 to 8.3 | ^2.1 - ^3.0 - ^4.0.x-dev | ^2.1 - ^3.0 - ^4.0.x-dev    | 04 May 2024  | 31 August 2026   | 31 December 2026 |
-| 6       | 8.4 - 8.5                   | 8.4 - 8.5       | ^3.6 - ^4.0.x-dev        | ^3.6 - ^4.0.x-dev           | August 2026  | 31 December 2027 | 31 December 2028 |
-| 7       | 8.4 - 8.5                   | 8.4 - 8.5       | ^3.6 - ^4.0.x-dev        | ^3.6 - ^4.0.x-dev           | Unknown      | Unknown          | Unknown          |
-| 8       | 8.5                         | 8.5             |                          | ^3.6 - ^4.0.x-dev           | January 2028 | 31 December 2028 | 31 December 2029 |
+| Version | PHP compatibility           | Tested on       | Doctrine ORM             | Tested against Doctrine ORM | Released       | Active support   | Security fixes   |
+|---------|-----------------------------|-----------------|--------------------------|-----------------------------|----------------|------------------|------------------|
+| 5       | 8.1 - 8.2 - 8.3 - 8.4 - 8.5 | From 8.1 to 8.3 | ^2.1 - ^3.0 - ^4.0.x-dev | ^2.1 - ^3.0 - ^4.0.x-dev    | 04 May 2024    | 31 August 2026   | 31 December 2026 |
+| 6       | 8.4 - 8.5                   | 8.4 - 8.5       | ^3.6 - ^4.0.x-dev        | ^3.6 - ^4.0.x-dev           | September 2026 | 31 December 2027 | 31 December 2028 |
+| 7       | 8.4 - 8.5                   | 8.4 - 8.5       | ^3.6 - ^4.0.x-dev        | ^3.6 - ^4.0.x-dev           | Unknown        | Unknown          | Unknown          |
+| 8       | 8.5                         | 8.5             |                          | ^3.6 - ^4.0.x-dev           | January 2028   | 31 December 2028 | 31 December 2029 |
 
 > [!NOTE]
 > **Why does PHP support jump between versions 5 and 6?**
@@ -65,34 +65,23 @@ Donations of coffee through [Ko-fi](https://ko-fi.com/longitudeone) will go eith
 
 ### Release
 
-| Status                      | Doctrine Spatial | PHP  | Doctrine ORM       |
-|-----------------------------|------------------|------|--------------------|
-| Stable (security fixes)     | **5.0**          | 8.1+ | `^2.9`, `^3.1`     |
-| Next release                | **6.0**          | 8.4+ | `^3.6`, `^4.x-dev` |
-| Next major version          | **7.0**          | 8.4+ | `^3.6`, `^4.x-dev` |
-| Planned for 1 January 2028  | **8.0**          | 8.5+ | `^3.6`, `^4.x-dev` |
+| Status                        | Doctrine Spatial | PHP  | Doctrine ORM       |
+|-------------------------------|------------------|------|--------------------|
+| Old-Stable (security fixes)   | **5.0**          | 8.1+ | `^2.9`, `^3.1`     |
+| Stable (bug and security fix) | **6.0**          | 8.4+ | `^3.6`, `^4.x-dev` |
+| Next major version            | **7.0**          | 8.4+ | `^3.6`, `^4.x-dev` |
+| Planned for 1 January 2028    | **8.0**          | 8.5+ | `^3.6`, `^4.x-dev` |
 
 ### Database testing
 
-The following versions reflect the database stack used in [the minimal database server test matrix](./.github/workflows/tests-minimum-database-versions.yaml).
+The [CI workflow](./.github/workflows/tests-php.yaml) tests the current development branch against the following database server versions.
 
-| Doctrine Spatial | MySQL    | MariaDB | PostgreSQL | PostGIS | SQL Server |
-|------------------|----------|---------|------------|---------|------------|
-| **5.0**          | 5.7, 8.0 | 10.6    | 18         | 3.6     | ❌          |
-| **6.0**          | 8.4      | 10.22   | 16         | 3.5     | 2023       |
-| **7.0**          | 8.4      | 10.22   | 16         | 3.5     | 2023       |
-| **8.0**          | 8.4      | 10.22   | 16         | 3.5     | 2023       |
+| Test job                  | PHP | MySQL | MariaDB | PostgreSQL | PostGIS | SQL Server |
+|---------------------------|-----|-------|---------|------------|---------|------------|
+| Minimum database versions | 8.4 | 8.4.  | 10.11   | 15         | 3.5     | 2022.      |
+| Maximum database versions | 8.5 | 9.6   | 12.3.   | 18         | 3.6     | 2025       |
 
-When successful, the following versions are tested using [the maximum database server test matrix](./.github/workflows/tests-maximum-database-versions.yaml).
-
-| Doctrine Spatial | MySQL    | MariaDB | PostgreSQL | PostGIS | SQL Server |
-|------------------|----------|---------|------------|---------|------------|
-| **5.0**          | 5.7, 8.0 | 10.6    | 18         | 3.6     | ❌          |
-| **6.0**          | 9.7      | 12.3    | 18         | 3.6     | 2025       |
-| **7.0**          | 9.7      | 12.3    | 18         | 3.6     | 2025       |
-| **8.0**          | 9.7      | 12.3    | 18         | 3.6     | 2025       |
-
-These versions may change rapidly as the test matrix evolves.
+These versions may change as the CI test matrix evolves.
 
 ## Known limitations
 
@@ -100,15 +89,15 @@ These versions may change rapidly as the test matrix evolves.
 
 You can work around this limitation by using the `ST_SetSRID` and `ST_SRID` spatial functions when needed. This allows SRIDs to be handled at the query level, even though they are not stored directly with the value.
 
+## Contributing
+
+Contributions, bug reports, and documentation improvements are welcome. Please refer to the documentation for the development workflow and test commands.
+
 ## Branch strategy
 
 The repository follows a structured release model:
 
-- **main** — No breaking changes; only the minimum supported versions of PHP and Doctrine ORM may change.
 - **5.0.x-dev** — Security updates for 5.0.x only.
+- **main**      — No breaking changes; only the minimum supported versions of PHP and Doctrine ORM may change.
 - **6.1.x-dev** — New features without breaking changes.
 - **7.0.x-dev** — New features with breaking changes.
-
-## Contributing
-
-Contributions, bug reports, and documentation improvements are welcome. Please refer to the documentation for the development workflow and test commands.

--- a/docs/Configuration.rst
+++ b/docs/Configuration.rst
@@ -24,8 +24,16 @@ Declare your geometric types
                 point:      LongitudeOne\Spatial\DBAL\Types\Geometry\PointType
                 polygon:    LongitudeOne\Spatial\DBAL\Types\Geometry\PolygonType
                 linestring: LongitudeOne\Spatial\DBAL\Types\Geometry\LineStringType
+            mapping_types:
+                geometry: geometry
+                point: point
+                polygon: polygon
+                linestring: linestring
 
 Now, you can :doc:`create an entity <./Entity>` with a ``geometry``, ``point``, ``polygon`` and a ``linestring`` type.
+
+The ``mapping_types`` entries let Doctrine introspect existing spatial columns. Each database type must map to one
+registered Doctrine type, so adapt these entries when using different type aliases.
 
 Here is a complete example showcasing all available spatial types supported by the Doctrine spatial extension.
 Notably, the names of these Doctrine types are not hardcoded. This means you have flexibility.
@@ -49,6 +57,18 @@ This customization allows you to tailor the extension's functionality to your sp
                 geometry_multilinestring: LongitudeOne\Spatial\DBAL\Types\Geometry\MultiLineStringType
                 geometry_multipoint:      LongitudeOne\Spatial\DBAL\Types\Geometry\MultiPointType
                 geometry_multipolygon:    LongitudeOne\Spatial\DBAL\Types\Geometry\MultiPolygonType
+            mapping_types:
+                geometry: geometry
+                geography: geography
+                point: geometry_point
+                linestring: geometry_linestring
+                polygon: geometry_polygon
+                multipoint: geometry_multipoint
+                multilinestring: geometry_multilinestring
+                multipolygon: geometry_multipolygon
+
+The subtype mappings use the geometric aliases because Doctrine can associate each native database type with only one
+Doctrine type. Platforms that expose only generic ``geometry`` or ``geography`` columns use the corresponding generic alias.
 
 I strive to keep this documentation up-to-date. However, if you ever encounter any discrepancies,
 you can refer directly to the source code. The `DBAL/Types`_ directory within the project repository contains all
@@ -81,7 +101,7 @@ Declare a new function
 
 Add only the functions you want to use. The list of available function can be found in these sections:
 
-1. list of :ref:`Standard functions` declared in the `Open Geospatial Consortium standard`_,
+1. list of :ref:`Standard functions` declared in the `Open Geospatial Consortium (OGC) standard`_,
 2. list of :ref:`Specific PostgreSQL functions` which are not already declared in the OGC Standard,
 3. list of :ref:`Specific MySQL functions` which are not already declared in the OGC Standard,
 
@@ -146,9 +166,10 @@ Coordinates order
 -----------------
 
 In point constructor, the order is the same as the spatial database.
-It means:
- * longitude shall be set before latitude in point constructor,
- * X shall be set before Y.
+This means:
+
+* longitude shall be set before latitude in the point constructor;
+* X shall be set before Y.
 
 .. _ISO/IEC 13249-3:2016: https://www.iso.org/standard/60343.html
 .. _Open Geospatial Consortium: https://www.ogc.org/

--- a/docs/Contributing.rst
+++ b/docs/Contributing.rst
@@ -15,12 +15,16 @@ The Doctrine Spatial project welcomes contributions in two primary areas:
 Documentation
 =============
 
-This documentation is done with sphinx. All documentation are stored in the ``docs`` directory. To contribute to this
-documentation (and fix the lot of typo), you could install docker and start the docker service named ``spatial_doc``.
-It's included in the repository. It will self-compile the documentation. After you start this service, you can now
-access the documentation at http://localhost:8100. If you try changing any ``rst`` file, after some seconds the browser
-auto refresh to show the updated documentation. Following the Sphinx documentation site you can now document this
-project using Sphinx.
+The documentation is built with Sphinx and its sources are stored in the ``docs`` directory. To preview changes locally,
+set ``APP_FOLDER`` as described in :doc:`the test environment guide <./Test>` and start the ``service_doc`` Compose service:
+
+.. code-block:: bash
+
+    cd docker
+    docker-compose up -d service_doc
+
+Open http://localhost:8800. The ``spatial-doc`` container runs ``sphinx-autobuild`` and reloads the site after changes to
+``.rst`` files.
 
 
 1. Edit files in the ``docs`` directory,
@@ -128,6 +132,8 @@ Here is an example of setup, each line is commented to help you to understand ho
     use LongitudeOne\Spatial\Tests\Helper\PointHelperTrait;
     use LongitudeOne\Spatial\Tests\OrmTestCase;
     use Doctrine\DBAL\Exception;
+    use Doctrine\DBAL\Platforms\MySQLPlatform;
+    use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
     use Doctrine\ORM\Exception\ORMException;
     use PHPUnit\Framework\Attributes\CoversClass;
 
@@ -163,10 +169,10 @@ Here is an example of setup, each line is commented to help you to understand ho
         {
             //If you create point entity in your test, you shall add the line above or the **next** test will failed
             $this->usesEntity(self::POINT_ENTITY);
-            //If the method exists in mysql, You shall test it. Comment this line if function does not exists on MySQL
-            $this->supportsPlatform('mysql');
-            //If the method exists in postgresql, You shall test it. Comment this line if function does not exists on PostgreSql
-            $this->supportsPlatform('postgresql');
+            // If the function is available on MySQL, test it there.
+            $this->supportsPlatform(MySQLPlatform::class);
+            // If the function is available on PostgreSQL, test it there.
+            $this->supportsPlatform(PostgreSQLPlatform::class);
 
             parent::setUp();
         }
@@ -182,7 +188,7 @@ Here is an example of setup, each line is commented to help you to understand ho
 
             //We create a query using your new DQL function SpFoo
             $query = $this->getEntityManager()->createQuery(
-                'SELECT p, ST_AsText(SpFoo(p.point, :p) FROM LongitudeOne\Spatial\Tests\Fixtures\PointEntity p'
+                'SELECT p, ST_AsText(SpFoo(p.point, :p)) FROM LongitudeOne\Spatial\Tests\Fixtures\PointEntity p'
             );
             //Optionnaly, you can use parameter
             $query->setParameter('p', 'bar', 'string');
@@ -195,32 +201,32 @@ Here is an example of setup, each line is commented to help you to understand ho
             static::assertSame('POLYGON((-4 -4,4 -4,4 4,-4 4,-4 -4))', $result[0][1]);
         }
 
-Now, open the `OrmTestCase.php file`_] and declare your function in one of this three methods:
+Now, open the `OrmTestCase.php file`_ and declare your function in the appropriate registration method:
 
 * ``addStandardFunctions``
-* ``addMySqlFunctions``
-* ``addPostgreSqlFunctions``
+* ``addSpecificMariaDbFunctions``
+* ``addSpecificMySqlFunctions``
+* ``addSpecificPostgreSqlFunctions``
+* ``addSpecificSqlServerFunctions``
 
 
 You can launch the test. This :doc:`document <./Test>` helps you how to config your dev environment.
-Please do not forgot to update documentation by adding your function in one of these three tables:
-
-* :ref:`Standard functions`
-* :ref:`Specific MySql functions`
-* :ref:`Specific PostgreSQL functions`
+Update the relevant table in :doc:`the glossary <./Glossary>`. If the function is specific to a platform not yet covered
+there, add a platform-specific section.
 
 Quality of your code
 ====================
 
-Quality of code is auto-verified by php-cs-fixer, php code sniffer and php mess detector.
+Code quality is checked by PHP-CS-Fixer, PHPStan, PHPMD, and PHP_CodeSniffer.
 
 Before a commit, install the quality scripts:
 
 .. code-block:: bash
-    docker exec spatial-php8 composer update --working-dir=quality/php-cs-fixer
-    docker exec spatial-php8 composer update --working-dir=quality/php-code-sniffer
-    docker exec spatial-php8 composer update --working-dir=quality/php-mess-detector
-    docker exec spatial-php8 composer update --working-dir=quality/php-stan
+
+    docker exec spatial-php8 composer install --working-dir=quality/php-cs-fixer
+    docker exec spatial-php8 composer install --working-dir=quality/php-code-sniffer
+    docker exec spatial-php8 composer install --working-dir=quality/php-mess-detector
+    docker exec spatial-php8 composer install --working-dir=quality/php-stan
 
 Then, you can check the quality of your code with:
 

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -15,17 +15,13 @@ Or you can edit directly `composer.json` file by adding this line on your requir
 .. code-block:: json
 
     "require": {
-        "longitude-one/doctrine-spatial": "^5.0"
+        "longitude-one/doctrine-spatial": "^6.0"
 
 Installation without composer
 -----------------------------
 
-While Composer is the recommended method for library management, you can
-:download:`download the library  <https://github.com/longitude-one/doctrine-spatial/archive/refs/heads/main.zip>` manually
-if needed.
-Once downloaded, locate the directory within the archive named `lib`.
-This directory typically contains the library's core files. Copy and paste this lib directory into the location where
-you store all your application's libraries.
+Manual installation is not supported. Doctrine Spatial relies on Composer-managed dependencies and PSR-4 autoloading.
+Use Composer to install and update the package.
 
 Installation to contribute
 --------------------------
@@ -34,6 +30,4 @@ We welcome your contributions to this project! Here's how you can easily get inv
 
 1. Fork the Project on GitHub: Head over to the project's GitHub repository and create a fork. This creates your own copy of the codebase that you can modify.
 2. Clone Your Fork Locally: Once you've forked the project, clone your forked repository to your local machine. This will allow you to work on the code locally.
-3. Refer to the Contribution Guide: The provided contribution guide (doc) offers detailed instructions on setting up your development environment, making code changes, and testing your contributions. This guide will ensure your contributions are aligned with the project's standards.
-
-
+3. Refer to the :doc:`contribution guide <./Contributing>` for instructions on setting up the development environment, making code changes, and testing contributions.

--- a/docs/Installation.rst
+++ b/docs/Installation.rst
@@ -8,14 +8,15 @@ Add the `longitude-one/doctrine-spatial` package in your composer.json.
 
 .. code-block:: bash
 
-    $ composer require longitude-one/doctrine-spatial
+    $ composer require longitude-one/doctrine-spatial:^6.0.0
 
 Or you can edit directly `composer.json` file by adding this line on your requirements:
 
 .. code-block:: json
 
     "require": {
-        "longitude-one/doctrine-spatial": "^6.0"
+        "longitude-one/doctrine-spatial": "^6.0.0"
+
 
 Installation without composer
 -----------------------------

--- a/docs/Test.rst
+++ b/docs/Test.rst
@@ -1,48 +1,46 @@
 Test environment
 ================
 
-If you want to contribute to this library, you're welcome. This section will help you to prepare your development
-environment.
+Doctrine Spatial is tested against MySQL, MariaDB, PostgreSQL/PostGIS, and SQL Server. The local development environment uses Docker Compose.
 
-How to prepare environment?
----------------------------
+Prepare the environment
+-----------------------
 
-Doctrine Spatial is tested against MySQL, MariaDB, PostgreSQL/PostGIS, and SQL Server.
-
-1. [Install docker](https://docs.docker.com/engine/install/),
-2. Go to the docker directory and start docker
+1. `Install Docker <https://docs.docker.com/engine/install/>`_.
+2. From the project root, set ``APP_FOLDER`` to the absolute path of the checkout and start the services:
 
 .. code-block:: bash
 
-    cd <project_directory>
+    export APP_FOLDER="$(pwd)"
     cd docker
     docker-compose up -d
     cd ..
 
-Done! Your environment is ready with six services:
+The Compose stack starts six services:
 
-1. A PostgreSQL/PostGIS service, available at ``postgresql://main:main@127.0.0.1:5432/main``.
-2. A MySQL 8.4 service, available at ``mysql://main:main@127.0.0.1:3306/main``.
-3. A MariaDB service, available at ``mysql://main:main@127.0.0.1:3310/main``.
-4. A SQL Server 2017 service, available at ``127.0.0.1:1433``.
-5. A PHP 8.4 service; check it with ``docker exec spatial-php8 php -v``.
-6. A documentation service, available at ``http://127.0.0.1:8800``.
+1. PostgreSQL/PostGIS, available at ``postgresql://main:main@127.0.0.1:5432/main``;
+2. MySQL 8.4, available at ``mysql://main:main@127.0.0.1:3306/main``;
+3. MariaDB (the current ``latest`` image), available at ``mysql://main:main@127.0.0.1:3310/main``;
+4. SQL Server 2017, available at ``127.0.0.1:1433``;
+5. PHP 8.4, available through the ``spatial-php8`` container;
+6. the Sphinx documentation server, available at ``http://127.0.0.1:8800``.
 
-Composer is installed on spatial-php8.
+Install dependencies and prepare PHPUnit
+----------------------------------------
 
-.. code-block:: bash
-
-    docker exec spatial-php8 composer -v
-
-How to start test?
---------------------------
-Copy docker/phpunit.*.xml to the project directory
+Composer is available in the PHP container. Install the project dependencies and copy the Docker PHPUnit configurations to the project root:
 
 .. code-block:: bash
 
+    docker exec spatial-php8 composer install
     cp docker/phpunit.*.xml .
 
-Then, you can run the test suites in the PHP container:
+The copied configurations use Docker service host names and must be run from the PHP container.
+
+Run tests
+---------
+
+Run an individual database suite, the PHP-only suite, or the complete test suite:
 
 .. code-block:: bash
 
@@ -50,9 +48,22 @@ Then, you can run the test suites in the PHP container:
     docker exec spatial-php8 composer test-mysql
     docker exec spatial-php8 composer test-pgsql
     docker exec spatial-php8 composer test-sqlserver
+    docker exec spatial-php8 composer test-php-only
+    docker exec spatial-php8 composer test
 
-After any update, before any commit, simply check your code with this composer command:
+To generate and merge coverage reports, run:
+
+.. code-block:: bash
+
+    docker exec spatial-php8 composer test-coverage
+
+Check code quality
+------------------
+
+Before committing, run the configured quality checks:
 
 .. code-block:: bash
 
     docker exec spatial-php8 composer quality
+
+This command runs PHP-CS-Fixer, PHPStan, PHPMD, and PHP_CodeSniffer. PHP-CS-Fixer may modify files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ author = 'Alexandre Tranchant'
 master_doc = 'index'
 
 # The full version, including alpha/beta/rc tags
-release = '5.0.0'
+release = '6.0.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,7 +8,7 @@ spatial entities and to store them into your database server.
 
 Currently, Doctrine-Spatial extension supports two-dimension geometric and geographic spatial types.
 These include points, linestrings, polygons, and their multi-dimensional counterparts
-(multi-points, multi-linestrings, and multi-polygons). It is compatible with MySQL and PostgreSQL databases.
+(multi-points, multi-linestrings, and multi-polygons). It supports MySQL, MariaDB, PostgreSQL/PostGIS, and SQL Server.
 
 This project was initially created by Derek J. Lambert in 2015. In March 2020, Alexandre Tranchant forked the originally
 project due to inactivity for two years. We welcome contribution (see the contribution :doc:`guide <./Contributing>`.
@@ -18,7 +18,7 @@ Here are some areas where your help would be appreciated:
 * Implementing support for third and fourth dimensions in spatial data,
 * Implementing new spatial functions,
 * Improving documentation by completing it and fixing typos *(even if your English isn't perfect, we can still use your help!)*
-* Implementing support for new database platforms, such as Microsoft SQL Server.
+* Improving support and test coverage across the supported database platforms.
 
 Contents
 ********

--- a/quality/commit-and-tag-version/installation-version-updater.cjs
+++ b/quality/commit-and-tag-version/installation-version-updater.cjs
@@ -1,0 +1,36 @@
+/**
+ * Custom updater for `commit-and-tag-version` to update Installation.rst.
+ *
+ * The built-in `plain-text` type replaces the entire file with the version number,
+ * which is unusable for Installation.rst. This updater replaces the version constraint
+ * for longitude-one/doctrine-spatial in each installation example.
+ */
+
+const SEMVER_PATTERN = '\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?';
+const PACKAGE_VERSION_PATTERN = new RegExp(
+  `(longitude-one\\/doctrine-spatial(?:":\\s*"|:)\\^)(${SEMVER_PATTERN})`,
+);
+const PACKAGE_VERSION_PATTERN_GLOBAL = new RegExp(
+  `(longitude-one\\/doctrine-spatial(?:":\\s*"|:)\\^)${SEMVER_PATTERN}`,
+  'g',
+);
+
+module.exports.readVersion = function (contents) {
+  const match = contents.match(PACKAGE_VERSION_PATTERN);
+  return match ? match[2] : '0.0.0';
+};
+
+module.exports.writeVersion = function (contents, version) {
+  const updatedContents = contents.replace(
+    PACKAGE_VERSION_PATTERN_GLOBAL,
+    `$1${version}`,
+  );
+
+  if (updatedContents === contents) {
+    throw new Error(
+      'installation-version-updater: No Doctrine Spatial package version found in Installation.rst.',
+    );
+  }
+
+  return updatedContents;
+};

--- a/quality/commit-and-tag-version/sphinx-release-updater.cjs
+++ b/quality/commit-and-tag-version/sphinx-release-updater.cjs
@@ -1,0 +1,29 @@
+/**
+ * Custom updater for `commit-and-tag-version` to update docs/conf.py.
+ */
+
+const SEMVER_PATTERN = '\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?';
+const RELEASE_PATTERN = new RegExp(
+  `^(\\s*release\\s*=\\s*['"])(${SEMVER_PATTERN})(['"].*)$`,
+  'm',
+);
+
+module.exports.readVersion = function (contents) {
+  const match = contents.match(RELEASE_PATTERN);
+  return match ? match[2] : '0.0.0';
+};
+
+module.exports.writeVersion = function (contents, version) {
+  const updatedContents = contents.replace(
+    RELEASE_PATTERN,
+    `$1${version}$3`,
+  );
+
+  if (updatedContents === contents) {
+    throw new Error(
+      'sphinx-release-updater: No Sphinx release value found in docs/conf.py.',
+    );
+  }
+
+  return updatedContents;
+};

--- a/tests/LongitudeOne/Spatial/Tests/ORM/Query/GeometryWalkerTest.php
+++ b/tests/LongitudeOne/Spatial/Tests/ORM/Query/GeometryWalkerTest.php
@@ -24,6 +24,7 @@ use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
 use LongitudeOne\Spatial\ORM\Query\GeometryWalker;
+use LongitudeOne\Spatial\PHP\Types\Geometry\Polygon;
 use LongitudeOne\Spatial\Tests\Helper\PersistantLineStringHelperTrait;
 use LongitudeOne\Spatial\Tests\Helper\PersistantPointHelperTrait;
 use LongitudeOne\Spatial\Tests\PersistOrmTestCase;
@@ -74,9 +75,10 @@ class GeometryWalkerTest extends PersistOrmTestCase
         string $envelope
     ): void {
         $queryString = sprintf(
-            'SELECT %s(%s(l.lineString)) FROM LongitudeOne\Spatial\Tests\Fixtures\LineStringEntity l',
+            'SELECT %s(%s(l.lineString)) FROM %s l',
             $convert,
-            $startPoint
+            $startPoint,
+            self::LINESTRING_ENTITY
         );
         $query = $entityManager->createQuery($queryString);
         $query->setHint(
@@ -92,19 +94,20 @@ class GeometryWalkerTest extends PersistOrmTestCase
         static::assertEquals(static::createPointC(), $result[1][1]);
 
         $queryString = sprintf(
-            'SELECT %s(%s(l.lineString)) FROM LongitudeOne\Spatial\Tests\Fixtures\LineStringEntity l',
+            'SELECT %s(%s(l.lineString)) FROM %s l',
             $convert,
-            $envelope
+            $envelope,
+            self::LINESTRING_ENTITY
         );
         $query = $entityManager->createQuery($queryString);
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'LongitudeOne\Spatial\ORM\Query\GeometryWalker');
+        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, GeometryWalker::class);
 
         $result = $query->getResult();
         static::assertIsArray($result);
         static::assertIsArray($result[0]);
         static::assertIsArray($result[1]);
-        static::assertInstanceOf('LongitudeOne\Spatial\PHP\Types\Geometry\Polygon', $result[0][1]);
-        static::assertInstanceOf('LongitudeOne\Spatial\PHP\Types\Geometry\Polygon', $result[1][1]);
+        static::assertInstanceOf(Polygon::class, $result[0][1]);
+        static::assertInstanceOf(Polygon::class, $result[1][1]);
     }
 
     /**


### PR DESCRIPTION
## Summary

- update the roadmap and release status for Doctrine Spatial 6.0;
- refresh installation, test, contribution, and Sphinx documentation;
- document Doctrine DBAL `mapping_types` for Symfony spatial types;
- add `commit-and-tag-version` updaters for `docs/Installation.rst` and `docs/conf.py`;
- exclude versioning configuration from package exports.

The Symfony `mapping_types` guidance builds on the issue raised in #141 by @arneee. Closes #141 .
Improve query string formatting and use class constants in GeometryWalkerTest in #135 by @shakaran. Closes #135 

## Validation

- `docker compose … sphinx-build -W -b html …`
- Node-based checks for both custom version updaters, including pre-release/build versions
- `git diff --check`

## Notes

The branch is five commits ahead of `main` and has no divergence from it.